### PR TITLE
switch off scalapack with directives

### DIFF
--- a/src/m_ci.f90
+++ b/src/m_ci.f90
@@ -1181,6 +1181,7 @@ subroutine full_ci_nelectrons_selfenergy()
 end subroutine full_ci_nelectrons_selfenergy
 
 
+#ifdef HAVE_SCALAPACK
 !==================================================================
 subroutine full_ci_nelectrons(save_coefficients,nelectron,spinstate,nuc_nuc)
  implicit none
@@ -1368,6 +1369,7 @@ subroutine full_ci_nelectrons(save_coefficients,nelectron,spinstate,nuc_nuc)
 
 
 end subroutine full_ci_nelectrons
+
 
 
 !=========================================================================
@@ -1685,7 +1687,7 @@ subroutine get_ab()
 end subroutine get_ab
 
 end subroutine diagonalize_davidson_ci
-
+#endif
 
 
 !==================================================================

--- a/src/m_scalapack.f90
+++ b/src/m_scalapack.f90
@@ -3141,7 +3141,7 @@ subroutine finish_scalapack()
 
 end subroutine finish_scalapack
 
-
+#ifdef HAVE_SCALAPACK
 !=========================================================================
 subroutine diagonalize_davidson_sca(tolerance,desc_ham,ham,neig,eigval,desc_vec,eigvec)
  implicit none
@@ -3332,8 +3332,9 @@ subroutine diagonalize_davidson_sca(tolerance,desc_ham,ham,neig,eigval,desc_vec,
 
 
 end subroutine diagonalize_davidson_sca
+#endif
 
-
+#ifdef HAVE_SCALAPACK
 !=========================================================================
 subroutine orthogonalize_sca(desc_vec,mvec_ortho,nvec_ortho,vec)
  implicit none
@@ -3368,7 +3369,7 @@ subroutine orthogonalize_sca(desc_vec,mvec_ortho,nvec_ortho,vec)
 
 
 end subroutine orthogonalize_sca
-
+#endif
 
 !=========================================================================
 subroutine select_nprow_npcol(scalapack_block_min,mmat,nmat,nprow,npcol)

--- a/src/molgw.f90
+++ b/src/molgw.f90
@@ -539,6 +539,7 @@ program molgw
 
    call prepare_ci(basis,MIN(nstate,nvirtualg-1),ncoreg,c_matrix)
 
+#ifdef HAVE_SCALAPACK
    call full_ci_nelectrons(0,NINT(electrons),ci_spin_multiplicity-1,en%nuc_nuc)
 
    if(calc_type%is_selfenergy) then
@@ -550,6 +551,9 @@ program molgw
      endif
      call full_ci_nelectrons_selfenergy()
    endif
+#else
+   write(6,*) 'only with scalapack'
+#endif
 
 
    if(has_auxil_basis) then


### PR DESCRIPTION
Hello Fabien,

I was compiling without scalapack and there were still some functions unavailable for linking. So, I did this quick hack. I am sure you may suggest a better solution---the one which would still allow CI for sequential runs.

Best regards,

Peter

PS. I found a simple set of instructions to install gcc6 without compilation from source and gcc6 has already the functionality of f2008. Therefore, I prefer not to pollute your code with preprocessing clauses. Maybe a note in your installation instructions should mention the compilation requirement of f2008... 