### PR TITLE
Change int4 to int8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 molgw
 molgw.tgz
+molgw_*
 *.mod
 *.o
 *.swp

--- a/config/my_machine_ifort_openmp.arch
+++ b/config/my_machine_ifort_openmp.arch
@@ -1,0 +1,35 @@
+#OPENMP=
+OPENMP= -qopenmp
+PYTHON=python
+#LIBTOOL=libtool --mode=link --tag=FC
+LIBTOOL=
+
+# Parallel MPI SCALAPACK compilation
+#FC=ftn -fpp
+#FC=mpif90 -fpp
+FC=ifort -fpp 
+
+#CPPFLAGS= -DHAVE_LIBXC -DHAVE_LIBINT_ONEBODY -DENABLE_YMBYUN -DENABLE_LIBXC_ALPHA -DHAVE_MPI -DHAVE_SCALAPACK
+CPPFLAGS= -DHAVE_LIBXC -DHAVE_LIBINT_ONEBODY -DENABLE_YMBYUN -DENABLE_LIBXC_ALPHA -DENABLE_OPENMP_AFFINITY
+
+CXX=icpc
+#FCOPTS= -O3 -xhost -qopt-matmul
+FCOPTS= -O2 -xHost -qopt-matmul #-I${MKLROOT}/include
+#CXXOPTS= -O3 -xhost
+CXXOPTS= -O2 -xHost
+
+#LAPACK= -mkl=sequential
+#LAPACK= ${MKLROOT}/lib/intel64/libmkl_scalapack_lp64.a -Wl,--start-group ${MKLROOT}/lib/intel64/libmkl_intel_lp64.a ${MKLROOT}/lib/intel64/libmkl_sequential.a ${MKLROOT}/lib/intel64/libmkl_core.a ${MKLROOT}/lib/intel64/libmkl_blacs_intelmpi_lp64.a -Wl,--end-group -lpthread -limf -ldl #-lm -ldl
+LAPACK= -Wl,--start-group ${MKLROOT}/lib/intel64/libmkl_intel_lp64.a ${MKLROOT}/lib/intel64/libmkl_intel_thread.a ${MKLROOT}/lib/intel64/libmkl_core.a -Wl,--end-group -liomp5 -lpthread -limf -ldl #-lm -ldl
+
+#SCALAPACK= -L${MKLROOT}/lib/intel64 -lmkl_scalapack_lp64 -lmkl_intel_lp64 -lmkl_sequential -lmkl_core -lmkl_blacs_openmpi_lp64 -lpthread -lm
+
+LIBXC_ROOT=/opt/libxc-3.0.0-HF.alpha.o-intel
+#LIBXC_ROOT=${HOME}/programs/libxc-3.0.0-HF.alpha.o-intel
+#LIBXC_ROOT=${HOME}/programs/libxc-3.0.0-HF.alpha.o-edison
+#LIBXC_ROOT=${HOME}/programs/libxc-3.0.0-HF.alpha.o-cori.haswell
+
+LIBINT_ROOT=/opt/libint-2.2.0-intel-N17.O1
+#LIBINT_ROOT=/storage/htc/ullrichlab/ybyun/programs/libint-2.2.0-intel-N17.O1-login
+#LIBINT_ROOT=${HOME}/programs/libint-2.2.0-edison
+#LIBINT_ROOT=${HOME}/programs/libint-2.2.0-cori.haswell

--- a/config/my_machine_ifort_openmp.arch
+++ b/config/my_machine_ifort_openmp.arch
@@ -1,6 +1,6 @@
 #OPENMP=
 OPENMP= -qopenmp
-PYTHON=python
+PYTHON=python3
 #LIBTOOL=libtool --mode=link --tag=FC
 LIBTOOL=
 

--- a/src/m_eri.f90
+++ b/src/m_eri.f90
@@ -33,7 +33,12 @@ module m_eri
 
 
  logical,protected,allocatable      :: negligible_shellpair(:,:)
- integer,private  ,allocatable      :: index_pair_1d(:)
+! ymbyun 2018/05/03
+#ifdef ENABLE_YMBYUN
+ integer(kind=8),private  ,allocatable      :: index_pair_1d(:)
+#else
+ integer,private  ,allocatable     :: index_pair_1d(:)
+#endif
  integer,protected,allocatable      :: index_basis(:,:)
  integer,protected,allocatable      :: index_shellpair(:,:)
  integer,protected                  :: nshellpair
@@ -42,8 +47,16 @@ module m_eri
 
 
  integer,private   :: nbf_eri         ! local copy of nbf
- integer,protected :: nsize           ! size of the eri_4center array
- integer,protected :: npair           ! number of independent pairs (i,j) with i<=j
+! ymbyun 2018/05/03
+! i4 is too small to store 4-center Coulomb integrals using no-RI/AE/5Z for 3d transition metals.
+! Maybe, MOLGW will need to use i8 by default in the future like NWChem.
+#ifdef ENABLE_YMBYUN
+ integer(kind=8),protected :: nsize      ! size of the eri_4center array
+ integer(kind=8),protected :: npair      ! number of independent pairs (i,j) with i<=j
+#else
+ integer,protected :: nsize             ! size of the eri_4center array
+ integer,protected :: npair             ! number of independent pairs (i,j) with i<=j
+#endif
 
  integer,protected :: nauxil_3center     ! size of the 3-center matrix
                                          ! may differ from the total number of 3-center integrals due to
@@ -174,10 +187,18 @@ pure function index_eri(ibf,jbf,kbf,lbf)
  implicit none
 
  integer,intent(in) :: ibf,jbf,kbf,lbf
+! ymbyun 2018/05/04
+#ifdef ENABLE_YMBYUN
+ integer(kind=8)    :: index_eri
+!=====
+ integer(kind=8)    :: klmin,ijmax
+ integer(kind=8)    :: index_ij,index_kl
+#else
  integer            :: index_eri
 !=====
  integer            :: klmin,ijmax
  integer            :: index_ij,index_kl
+#endif
 !=====
 
  index_ij = index_pair(ibf,jbf)
@@ -197,7 +218,12 @@ pure function index_pair(ibf,jbf)
  implicit none
 
  integer,intent(in) :: ibf,jbf
+! ymbyun 2018/05/05
+#ifdef ENABLE_YMBYUN
+ integer(kind=8)    :: index_pair
+#else
  integer            :: index_pair
+#endif
 !=====
  integer            :: ijmin,ijmax
 !=====
@@ -255,7 +281,12 @@ function eri_ri(ibf,jbf,kbf,lbf)
  integer,intent(in) :: ibf,jbf,kbf,lbf
  real(dp)           :: eri_ri
 !=====
+! ymbyun 2018/05/05
+#ifdef ENABLE_YMBYUN
+ integer(kind=8)    :: index_ij,index_kl
+#else
  integer            :: index_ij,index_kl
+#endif
 !=====
 
  if( negligible_basispair(ibf,jbf) .OR. negligible_basispair(kbf,lbf) ) then
@@ -279,7 +310,12 @@ function eri_ri_lr(ibf,jbf,kbf,lbf)
  integer,intent(in) :: ibf,jbf,kbf,lbf
  real(dp)           :: eri_ri_lr
 !=====
+! ymbyun 2018/05/04
+#ifdef ENABLE_YMBYUN
+ integer(kind=8)    :: index_ij,index_kl
+#else
  integer            :: index_ij,index_kl
+#endif
 !=====
 
  if( negligible_basispair(ibf,jbf) .OR. negligible_basispair(kbf,lbf) ) then
@@ -622,7 +658,12 @@ subroutine negligible_eri(tol)
  real(dp),intent(in) :: tol
 !=====
  integer             :: icount,ibf,jbf,kbf,lbf,jcount
+! ymbyun 2018/05/04
+#ifdef ENABLE_YMBYUN
+ integer(kind=8)     :: ibuffer
+#else
  integer             :: ibuffer
+#endif
  real(dp)            :: integral_ij(nbf_eri,nbf_eri)
 !=====
 
@@ -668,7 +709,12 @@ subroutine dump_out_eri(rcut)
  real(dp),intent(in) :: rcut
 !=====
  character(len=50) :: filename
+! ymbyun 2018/05/04
+#ifdef ENABLE_YMBYUN
+ integer(kind=8)   :: nline,iline,icurrent
+#else
  integer           :: nline,iline,icurrent
+#endif
  integer           :: erifile
 !=====
 
@@ -706,8 +752,14 @@ logical function read_eri(rcut)
  real(dp),intent(in) :: rcut
 !=====
  character(len=50) :: filename
+! ymbyun 2018/05/04
+#ifdef ENABLE_YMBYUN
+ integer(kind=8)   :: nline,iline,icurrent
+ integer(kind=8)   :: integer_read
+#else
  integer           :: nline,iline,icurrent
  integer           :: integer_read
+#endif
  real(dp)          :: real_read
  integer           :: erifile
 !=====

--- a/src/m_eri_calculate.f90
+++ b/src/m_eri_calculate.f90
@@ -42,7 +42,13 @@ subroutine calculate_eri(print_eri_,basis,rcut)
  call start_clock(timing_eri_4center)
 
  if( incore_ ) then
+   ! ymbyun 2018/05/03
+   ! From now on, the array index for 4-center Coulomb integrals can be greater than 2^32.
+#ifdef ENABLE_YMBYUN
+   write(stdout,'(/,a,i16)') ' Number of integrals to be stored: ',nsize
+#else
    write(stdout,'(/,a,i12)') ' Number of integrals to be stored: ',nsize
+#endif
 
    if( rcut < 1.0e-12_dp ) then
      call clean_allocate('4-center integrals',eri_4center,nsize)
@@ -874,8 +880,15 @@ subroutine calculate_eri_3center_scalapack(basis,auxil_basis,rcut)
  ! Set mlocal => auxil_basis%nbf
  ! Set nlocal => npair
  mlocal = NUMROC(auxil_basis%nbf,block_row,iprow_3center,first_row,nprow_3center)
+! ymbyun 2018/05/21
+! From now on, npair is an 8-byte integer.
+#ifdef ENABLE_YMBYUN
+ nlocal = NUMROC(INT(npair)     ,block_col,ipcol_3center,first_col,npcol_3center)
+ call DESCINIT(desc3center,auxil_basis%nbf,INT(npair),block_row,block_col,first_row,first_col,cntxt_3center,MAX(1,mlocal),info)
+#else
  nlocal = NUMROC(npair          ,block_col,ipcol_3center,first_col,npcol_3center)
  call DESCINIT(desc3center,auxil_basis%nbf,npair,block_row,block_col,first_row,first_col,cntxt_3center,MAX(1,mlocal),info)
+#endif
 
  !  Allocate the 3-center integral array
  !
@@ -986,9 +999,15 @@ subroutine calculate_eri_3center_scalapack(basis,auxil_basis,rcut)
  ! Set mlocal => nauxil_kept = nauxil_2center OR nauxil_2center_lr
  ! Set nlocal => npair
  mlocal = NUMROC(nauxil_kept,block_row,iprow_3center,first_row,nprow_3center)
+! ymbyun 2018/05/21
+! From now on, npair is an 8-byte integer.
+#ifdef ENABLE_YMBYUN
+ nlocal = NUMROC(INT(npair) ,block_col,ipcol_3center,first_col,npcol_3center)
+ call DESCINIT(desc3tmp,nauxil_kept,INT(npair),block_row,block_col,first_row,first_col,cntxt_3center,MAX(1,mlocal),info)
+#else
  nlocal = NUMROC(npair      ,block_col,ipcol_3center,first_col,npcol_3center)
  call DESCINIT(desc3tmp,nauxil_kept,npair,block_row,block_col,first_row,first_col,cntxt_3center,MAX(1,mlocal),info)
-
+#endif
 
 
 

--- a/src/m_memory.f90
+++ b/src/m_memory.f90
@@ -252,8 +252,7 @@ subroutine clean_allocate_i2d_i4_84(array_name,array,n1,n2)
 !=====
 
  if( ALLOCATED(array) ) then
-   call die('clean_allocate: Cannot allocate. This array is already allocated ->
-'//TRIM(array_name))
+   call die('clean_allocate: Cannot allocate. This array is already allocated ->'//TRIM(array_name))
  endif
 
  mem_mb = REAL(4,dp) * REAL(n1,dp) * REAL(n2,dp) / 1024._dp**2
@@ -325,8 +324,7 @@ subroutine clean_allocate_1d_8(array_name,array,n1)
 !=====
 
  if( ALLOCATED(array) ) then
-   call die('clean_allocate: Cannot allocate. This array is already allocated ->
-'//TRIM(array_name))
+   call die('clean_allocate: Cannot allocate. This array is already allocated ->'//TRIM(array_name))
  endif
 
  mem_mb = REAL(dp,dp) * REAL(n1,dp) / 1024._dp**2

--- a/src/m_memory.f90
+++ b/src/m_memory.f90
@@ -16,12 +16,22 @@ module m_memory
 
  interface clean_allocate
   module procedure clean_allocate_i1d
+#ifdef ENABLE_YMBYUN
+  module procedure clean_allocate_i1d_i8_4   ! ymbyun 2018/05/04
+#endif
   module procedure clean_allocate_i2d
+#ifdef ENABLE_YMBYUN
+  module procedure clean_allocate_i2d_i4_48  ! ymbyun 2018/05/03
+  module procedure clean_allocate_i2d_i4_84  ! ymbyun 2018/05/04
+#endif
   module procedure clean_allocate_s1d
   module procedure clean_allocate_s2d
   module procedure clean_allocate_s3d
   module procedure clean_allocate_s4d
   module procedure clean_allocate_1d
+#ifdef ENABLE_YMBYUN
+  module procedure clean_allocate_1d_8       ! ymbyun 2018/05/03
+#endif
   module procedure clean_allocate_2d
   module procedure clean_allocate_2d_range
   module procedure clean_allocate_3d
@@ -32,6 +42,9 @@ module m_memory
 
  interface clean_deallocate
   module procedure clean_deallocate_i1d
+#ifdef ENABLE_YMBYUN
+  module procedure clean_deallocate_i1d_i8   ! ymbyun 2018/05/05
+#endif
   module procedure clean_deallocate_i2d
   module procedure clean_deallocate_s1d
   module procedure clean_deallocate_s2d
@@ -109,6 +122,46 @@ subroutine clean_allocate_i1d(array_name,array,n1)
 
 end subroutine clean_allocate_i1d
 
+#ifdef ENABLE_YMBYUN
+! ymbyun 2018/05/04
+!=========================================================================
+subroutine clean_allocate_i1d_i8_4(array_name,array,n1)
+ implicit none
+
+ character(len=*),intent(in)               :: array_name
+! integer,allocatable,intent(inout)        :: array(:)
+ integer(kind=8),allocatable,intent(inout) :: array(:)
+ integer,intent(in)                        :: n1
+!=====
+ integer             :: info
+ real(dp)            :: mem_mb
+!=====
+
+ if( ALLOCATED(array) ) then
+   call die('clean_allocate: Cannot allocate. This array is already allocated ->'//TRIM(array_name))
+ endif
+
+! ymbyun 2018/05/04
+! integer(kind=8) is used instead of integer(kind=4)
+! mem_mb = REAL(4,dp) * REAL(n1,dp) / 1024._dp**2
+ mem_mb = REAL(8,dp) * REAL(n1,dp) / 1024._dp**2
+
+ ! The allocation itself
+ allocate(array(n1),stat=info)
+
+ if(info/=0) then
+   write(stdout,'(a,a)')    ' Failure when allocating ',array_name
+   write(stdout,'(a,f9.3)') ' with size (Mb) ',mem_mb
+   call die('clean_allocate: Not enough memory. Buy a bigger computer')
+ endif
+
+ total_memory = total_memory + mem_mb
+ peak_memory = MAX(peak_memory,total_memory)
+
+ call write_memory_allocate(array_name,mem_mb)
+
+end subroutine clean_allocate_i1d_i8_4
+#endif
 
 !=========================================================================
 subroutine clean_allocate_i2d(array_name,array,n1,n2)
@@ -145,6 +198,82 @@ subroutine clean_allocate_i2d(array_name,array,n1,n2)
 
 end subroutine clean_allocate_i2d
 
+#ifdef ENABLE_YMBYUN
+! ymbyun 2018/05/03
+!=========================================================================
+subroutine clean_allocate_i2d_i4_48(array_name,array,n1,n2)
+ implicit none
+
+ character(len=*),intent(in)       :: array_name
+ integer,allocatable,intent(inout) :: array(:,:)
+! integer,intent(in)               :: n1,n2
+ integer,intent(in)                :: n1
+ integer(kind=8),intent(in)        :: n2
+!=====
+ integer             :: info
+ real(dp)            :: mem_mb
+!=====
+
+ if( ALLOCATED(array) ) then
+   call die('clean_allocate: Cannot allocate. This array is already allocated ->'//TRIM(array_name))
+ endif
+
+ mem_mb = REAL(4,dp) * REAL(n1,dp) * REAL(n2,dp) / 1024._dp**2
+
+ ! The allocation itself
+ allocate(array(n1,n2),stat=info)
+
+ if(info/=0) then
+   write(stdout,'(a,a)')    ' Failure when allocating ',array_name
+   write(stdout,'(a,f9.3)') ' with size (Mb) ',mem_mb
+   call die('clean_allocate: Not enough memory. Buy a bigger computer')
+ endif
+
+ total_memory = total_memory + mem_mb
+ peak_memory = MAX(peak_memory,total_memory)
+
+ call write_memory_allocate(array_name,mem_mb)
+
+end subroutine clean_allocate_i2d_i4_48
+
+! ymbyun 2018/05/04
+!=========================================================================
+subroutine clean_allocate_i2d_i4_84(array_name,array,n1,n2)
+ implicit none
+
+ character(len=*),intent(in)       :: array_name
+ integer,allocatable,intent(inout) :: array(:,:)
+! integer,intent(in)               :: n1,n2
+ integer(kind=8),intent(in)        :: n1
+ integer,intent(in)                :: n2
+!=====
+ integer             :: info
+ real(dp)            :: mem_mb
+!=====
+
+ if( ALLOCATED(array) ) then
+   call die('clean_allocate: Cannot allocate. This array is already allocated ->
+'//TRIM(array_name))
+ endif
+
+ mem_mb = REAL(4,dp) * REAL(n1,dp) * REAL(n2,dp) / 1024._dp**2
+
+ ! The allocation itself
+ allocate(array(n1,n2),stat=info)
+
+ if(info/=0) then
+   write(stdout,'(a,a)')    ' Failure when allocating ',array_name
+   write(stdout,'(a,f9.3)') ' with size (Mb) ',mem_mb
+   call die('clean_allocate: Not enough memory. Buy a bigger computer')
+ endif
+
+ total_memory = total_memory + mem_mb
+ peak_memory = MAX(peak_memory,total_memory)
+
+ call write_memory_allocate(array_name,mem_mb)
+
+end subroutine clean_allocate_i2d_i4_84
+#endif
 
 !=========================================================================
 subroutine clean_allocate_1d(array_name,array,n1)
@@ -180,6 +309,43 @@ subroutine clean_allocate_1d(array_name,array,n1)
 
 end subroutine clean_allocate_1d
 
+#ifdef ENABLE_YMBYUN
+! ymbyun 2018/05/03
+!=========================================================================
+subroutine clean_allocate_1d_8(array_name,array,n1)
+ implicit none
+
+ character(len=*),intent(in)        :: array_name
+ real(dp),allocatable,intent(inout) :: array(:)
+! integer,intent(in)                :: n1
+ integer(kind=8),intent(in)         :: n1
+!=====
+ integer             :: info
+ real(dp)            :: mem_mb
+!=====
+
+ if( ALLOCATED(array) ) then
+   call die('clean_allocate: Cannot allocate. This array is already allocated ->
+'//TRIM(array_name))
+ endif
+
+ mem_mb = REAL(dp,dp) * REAL(n1,dp) / 1024._dp**2
+
+ ! The allocation itself
+ allocate(array(n1),stat=info)
+
+ if(info/=0) then
+   write(stdout,*) 'failure'
+   call die('clean_allocate: Not enough memory. Buy a bigger computer')
+ endif
+
+ total_memory = total_memory + mem_mb
+ peak_memory = MAX(peak_memory,total_memory)
+
+ call write_memory_allocate(array_name,mem_mb)
+
+end subroutine clean_allocate_1d_8
+#endif
 
 !=========================================================================
 subroutine clean_allocate_2d(array_name,array,n1,n2)
@@ -417,6 +583,39 @@ subroutine clean_deallocate_i1d(array_name,array)
 
 end subroutine clean_deallocate_i1d
 
+#ifdef ENABLE_YMBYUN
+! ymbyun 2018/05/05
+!=========================================================================
+subroutine clean_deallocate_i1d_i8(array_name,array)
+ implicit none
+
+ character(len=*),intent(in)               :: array_name
+! integer,allocatable,intent(inout)        :: array(:)
+ integer(kind=8),allocatable,intent(inout) :: array(:)
+!=====
+ integer             :: info
+ real(dp)            :: mem_mb
+ integer             :: n1
+!=====
+
+ if( .NOT. ALLOCATED(array) ) return
+
+ n1 = SIZE(array(:),DIM=1)
+
+! ymbyun 2018/05/05
+! integer(kind=8) is used instead of integer(kind=4).
+! mem_mb = REAL(4,dp) * REAL(n1,dp) / 1024._dp**2
+ mem_mb = REAL(8,dp) * REAL(n1,dp) / 1024._dp**2
+
+ ! The allocation itself
+ deallocate(array)
+
+ total_memory = total_memory - mem_mb
+
+ call write_memory_deallocate(array_name,mem_mb)
+
+end subroutine clean_deallocate_i1d_i8
+#endif
 
 !=========================================================================
 subroutine clean_deallocate_i2d(array_name,array)
@@ -426,11 +625,18 @@ subroutine clean_deallocate_i2d(array_name,array)
  integer,allocatable,intent(inout) :: array(:,:)
 !=====
  real(dp)            :: mem_mb
+! ymbyun 2018/05/05
+#ifdef ENABLE_YMBYUN
+ integer(kind=8)     :: n1,n2
+#else
  integer             :: n1,n2
+#endif
 !=====
 
  if( .NOT. ALLOCATED(array) ) return
 
+! ymbyun 2018/05/05
+! I'm not sure if SIZE() can return an 8-byte integer.
  n1 = SIZE(array(:,:),DIM=1)
  n2 = SIZE(array(:,:),DIM=2)
 
@@ -454,11 +660,18 @@ subroutine clean_deallocate_1d(array_name,array)
  real(dp),allocatable,intent(inout) :: array(:)
 !=====
  real(dp)            :: mem_mb
+! ymbyun 2018/05/03
+#ifdef ENABLE_YMBYUN
+ integer(kind=8)     :: n1
+#else
  integer             :: n1
+#endif
 !=====
 
  if( .NOT. ALLOCATED(array) ) return
 
+! ymbyun 2018/05/05
+! I'm not sure if SIZE() can return an 8-byte integer.
  n1 = SIZE(array(:))
 
  mem_mb = REAL(dp,dp) * REAL(n1,dp) / 1024._dp**2


### PR DESCRIPTION
I changed a few things:

- I changed the integer type of the array index for 4-center ERI from 4 bytes to 8 bytes.
- I added my_machine_ifort_openmp.arch to the config directory.
- I added molgw_* to the .gitignore file.

There is one thing to note:

- My changes become enabled only when the -DENABLE_YMBYUN flag is used in Makefile (see my_machine_ifort_openmp.arch).

Please let me know if you have any questions.