### PR TITLE
Add a no-RI scCOHSEX test input file

### DIFF
--- a/tests/inputs/be_cohsex.in
+++ b/tests/inputs/be_cohsex.in
@@ -3,7 +3,7 @@
  tolscf=1.0e-9
 
  basis='cc-pVDZ'
- auxil_basis='cc-pVDZ-RI'
+! auxil_basis='cc-pVDZ-RI'
  basis_path='../../basis'
 
  natom=1

--- a/tests/inputs/be_cohsex_ri.in
+++ b/tests/inputs/be_cohsex_ri.in
@@ -1,0 +1,14 @@
+&molgw
+ scf='cohsex'
+ tolscf=1.0e-9
+
+ basis='cc-pVDZ'
+ auxil_basis='cc-pVDZ-RI'
+ basis_path='../../basis'
+
+ natom=1
+ alpha_mixing=0.5
+ mixing_scheme='simple'
+ nscf=100
+/
+Be 0. 0. 0.

--- a/tests/inputs/testsuite
+++ b/tests/inputs/testsuite
@@ -273,7 +273,11 @@ MP2 Total Energy          ,    -14.5997371900  , 0 , 1.0e-7
 gKS HOMO energy           ,     -8.817876      , 0 , 1.0e-4
 gKS LUMO energy           ,      1.203606      , 0 , 1.0e-4
 
-be_cohsex.in              , self-consistent COHSEX Be atom cc-pVDZ with RI
+be_cohsex.in              , self-consistent COHSEX Be atom cc-pVDZ without RI
+gKS HOMO energy           ,     -9.681301      , 0 , 1.0e-4
+gKS LUMO energy           ,      1.134290      , 0 , 1.0e-4
+
+be_cohsex_ri.in           , self-consistent COHSEX Be atom cc-pVDZ with RI
 gKS HOMO energy           ,     -9.681476      , 0 , 1.0e-4
 gKS LUMO energy           ,      1.133775      , 0 , 1.0e-4
 


### PR DESCRIPTION
Hi Fabien,

In this pull request, I added the **be_cohsex_nori.in** file. Lately, I have been testing COHSEX and QSGW and found that no-RI with OpenMP frequently and randomly causes an error in COHSEX and QSGW. This test file will help users detect the error.

Best,
Young-Moo 