### PR TITLE
Add OpenMP to PT2

### DIFF
--- a/src/pt_selfenergy.f90
+++ b/src/pt_selfenergy.f90
@@ -81,7 +81,11 @@ subroutine pt2_selfenergy(selfenergy_approx,nstate,basis,occupation,energy,c_mat
      do pstate=nsemin,nsemax ! external loop ( bra )
        qstate=pstate         ! external loop ( ket )
 
-
+! ymbyun 2019/09/23
+! NOTE: OpenMP 2.0 (2000) supports array reductions for Fortran, while OpenMP 4.5 (2015) supports array reductions for C/C++.
+! NOTE: If pstate is moved into the kstate loop, performance increases slightly but readability decreases significantly.
+!$OMP PARALLEL
+!$OMP DO PRIVATE(jkspin, jstate,fj,ej, kstate,fk,ek,fact_occ1,fact_occ2,coul_ipkj,coul_iqjk,coul_ijkq, iomega,omega,fact_real,fact_energy) REDUCTION(+:emp2_ring,emp2_sox,selfenergy_ring,selfenergy_sox) COLLAPSE(2)
        do jkspin=1,nspin
          do jstate=ncore_G+1,nvirtual_G-1  !LOOP of the second Green's function
            fj = occupation(jstate,jkspin)
@@ -143,6 +147,8 @@ subroutine pt2_selfenergy(selfenergy_approx,nstate,basis,occupation,energy,c_mat
            enddo
          enddo
        enddo
+!$OMP END DO
+!$OMP END PARALLEL
      enddo
    enddo
  enddo ! pqispin
@@ -174,7 +180,13 @@ subroutine pt2_selfenergy(selfenergy_approx,nstate,basis,occupation,energy,c_mat
    emp2 = 0.0_dp
  endif
 
+! ymbyun 2019/09/25
+! NOTE: A performance test is needed.
+!$OMP PARALLEL
+!$OMP WORKSHARE
  se%sigma(:,:,:) = selfenergy_ring(:,:,:) + selfenergy_sox(:,:,:)
+!$OMP END WORKSHARE
+!$OMP END PARALLEL
 
  write(stdout,'(/,1x,a)') ' Spin  State      1-ring             SOX              PT2'
  do pqispin=1,nspin
@@ -318,6 +330,10 @@ subroutine pt2_selfenergy_qs(nstate,basis,occupation,energy,c_matrix,s_matrix,se
      fi = occupation(istate,pqispin)
      ei = energy(istate,pqispin)
 
+! ymbyun 2019/09/23
+! NOTE: OpenMP 2.0 (2000) supports array reductions for Fortran, while OpenMP 4.5 (2015) supports array reductions for C/C++.
+!$OMP PARALLEL
+!$OMP DO PRIVATE(pstate, qstate, jkspin, jstate,fj,ej, kstate,fk,ek,fact_occ1,fact_occ2,coul_ipkj,coul_iqjk,coul_ijkq,ep,eq,fact_real,fact_energy) REDUCTION(+:emp2_ring,emp2_sox,selfenergy_ring,selfenergy_sox) COLLAPSE(4)
      do pstate=nsemin,nsemax ! external loop ( bra )
        do qstate=nsemin,nsemax   ! external loop ( ket )
 
@@ -337,6 +353,9 @@ subroutine pt2_selfenergy_qs(nstate,basis,occupation,energy,c_matrix,s_matrix,se
                if( fact_occ1 < completely_empty .AND. fact_occ2 < completely_empty ) cycle
 
                if( has_auxil_basis ) then
+                 ! ymbyun 2019/10/01
+                 ! NOTE: This part is a bottleneck.
+                 ! NOTE: We should minimize the number of calls to MPI_Allreduce at this part using mpi_nproc_ortho.
                  coul_ipkj = eri_eigen_ri(istate,pstate,pqispin,kstate,jstate,jkspin)
                  coul_iqjk = eri_eigen_ri(istate,qstate,pqispin,jstate,kstate,jkspin)
                  if( pqispin == jkspin ) then
@@ -384,9 +403,20 @@ subroutine pt2_selfenergy_qs(nstate,basis,occupation,energy,c_matrix,s_matrix,se
          enddo
        enddo
      enddo
+!$OMP END DO
+!$OMP END PARALLEL
    enddo
  enddo ! pqispin
 
+ ! ymbyun 2019/10/06
+ ! NOTE: This part is a bottleneck.
+ ! NOTE: Currently, no-RI (OpenMP) is faster than RI (MPI).
+ ! NOTE: For intra-node MPI communication, Ethernet (MPICH) is faster than InfiniBand (MVAPICH2) and Aries (Cray MPICH).
+ ! TODO: Tests for communication time and computation time
+ ! TODO: Tests for inter-node MPI communication
+ ! TODO: Tests for MV2_SHMEM_ALLREDUCE_MSG and MV2_ALLREDUCE_2LEVEL_MSG in MVAPICH2
+ ! TODO: Tests for MPI-3 shared memory
+ ! TODO: Tests for OpenMPI
  call xsum_ortho(selfenergy_ring)
  call xsum_ortho(selfenergy_sox)
  call xsum_ortho(emp2_ring)
@@ -404,8 +434,13 @@ subroutine pt2_selfenergy_qs(nstate,basis,occupation,energy,c_matrix,s_matrix,se
    emp2 = 0.0_dp
  endif
 
-
+! ymbyun 2019/09/25
+! NOTE: A performance test is needed.
+!$OMP PARALLEL
+!$OMP WORKSHARE
  selfenergy(:,:,:) = REAL( selfenergy_ring(:,:,:) + selfenergy_sox(:,:,:) ,dp)
+!$OMP END WORKSHARE
+!$OMP END PARALLEL
 
  call apply_qs_approximation(s_matrix,c_matrix,selfenergy)
 

--- a/tests/inputs/be_qspt2.in
+++ b/tests/inputs/be_qspt2.in
@@ -1,0 +1,12 @@
+&molgw
+ scf='pt2'
+
+ basis='cc-pVDZ'
+! auxil_basis='cc-pVDZ-RI'
+
+ natom=1
+ alpha_mixing=0.5
+ mixing_scheme='simple'
+ nscf=100
+/
+Be 0. 0. 0.

--- a/tests/inputs/testsuite
+++ b/tests/inputs/testsuite
@@ -283,6 +283,11 @@ RPA Total energy          ,    -14.6146048917  , 0 , 1.0e-7
 gKS HOMO energy           ,     -8.944487      , 0 , 1.0e-4
 gKS LUMO energy           ,      1.282521      , 0 , 1.0e-4
 
+be_qspt2.in               , QSPT2 Be atom cc-pVDZ without RI
+MP2 Total Energy          ,    -14.5995945786  , 0 , 1.0e-7
+gKS HOMO energy           ,     -8.817690      , 0 , 1.0e-4
+gKS LUMO energy           ,      1.204203      , 0 , 1.0e-4
+
 be_qspt2_ri.in            , QSPT2 Be atom cc-pVDZ with RI
 MP2 Total Energy          ,    -14.5997371900  , 0 , 1.0e-7
 gKS HOMO energy           ,     -8.817876      , 0 , 1.0e-4


### PR DESCRIPTION
Hi Fabien,

Here, I added OpenMP to one-shot PT2 and QSPT2. There are a couple of things to note:

- Currently, **RI (MPI) QSPT2 is slower than no-RI (OpenMP) QSPT2** when the number of basis functions (NBF) is greater than 100. (I didn't test yet what happens when NBF < 100)
- You can find my test results for **MPI_Allreduce** at my comments.

Please let me know if you have any questions.

Young-Moo 